### PR TITLE
FIX: findEvent without title breaks the search-string

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -221,10 +221,18 @@
         [predicateString appendString:[NSString stringWithFormat:@"title == '%@'", title]];
     }
     if (location != (id)[NSNull null] && location.length > 0) {
-        [predicateString appendString:[NSString stringWithFormat:@" AND location == '%@'", location]];
+    
+    	if (predicateString.length > 0) {
+            [predicateString appendString:@" AND "];
+    	}    
+        [predicateString appendString:[NSString stringWithFormat:@"location == '%@'", location]];
     }
     if (notes != (id)[NSNull null] && notes.length > 0) {
-        [predicateString appendString:[NSString stringWithFormat:@" AND notes == '%@'", notes]];
+    
+    	if (predicateString.length > 0) {
+            [predicateString appendString:@" AND "];
+    	}
+        [predicateString appendString:[NSString stringWithFormat:@"notes == '%@'", notes]];
     }
     
     NSPredicate *matches = [NSPredicate predicateWithFormat:predicateString];


### PR DESCRIPTION
`window.plugins.calendar.findEvent(null,null,"Test",startDate,endDate,success,error)` ends in a broken search term: `" AND notes == 'Test'"` and not  `"notes == 'Test'"`
