### PR TITLE
#55 fixed all day events for Android so the event is on the start date i...

### DIFF
--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -431,8 +431,8 @@ public abstract class AbstractCalendarAccessor {
       final boolean allDayEvent = isAllDayEvent(new Date(startTime), new Date(endTime));
       values.put(Events.EVENT_TIMEZONE, TimeZone.getDefault().getID());
       values.put(Events.ALL_DAY, allDayEvent ? 1 : 0);
-      values.put(Events.DTSTART, allDayEvent ? startTime+(1000*60*60*24) : startTime);
-      values.put(Events.DTEND, endTime);
+      values.put(Events.DTSTART, startTime);
+      values.put(Events.DTEND, allDayEvent ? endTime-(1000*60*60*24) : endTime);
       values.put(Events.TITLE, title);
       values.put(Events.DESCRIPTION, description);
       values.put(Events.HAS_ALARM, 1);

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -429,10 +429,17 @@ public abstract class AbstractCalendarAccessor {
       ContentResolver cr = this.cordova.getActivity().getContentResolver();
       ContentValues values = new ContentValues();
       final boolean allDayEvent = isAllDayEvent(new Date(startTime), new Date(endTime));
-      values.put(Events.EVENT_TIMEZONE, TimeZone.getDefault().getID());
+      if (allDayEvent) {
+        //all day events must be in UTC time zone per Android specification, getOffset accounts for daylight savings time
+        values.put(Events.EVENT_TIMEZONE, TimeZone.getTimeZone("UTC").getID());
+        values.put(Events.DTSTART, startTime + TimeZone.getDefault().getOffset(startTime));
+        values.put(Events.DTEND, endTime + TimeZone.getDefault().getOffset(endTime));
+      } else {
+        values.put(Events.EVENT_TIMEZONE, TimeZone.getDefault().getID());
+        values.put(Events.DTSTART, startTime);
+        values.put(Events.DTEND, endTime);
+	  }
       values.put(Events.ALL_DAY, allDayEvent ? 1 : 0);
-      values.put(Events.DTSTART, startTime);
-      values.put(Events.DTEND, allDayEvent ? endTime-(1000*60*60*24) : endTime);
       values.put(Events.TITLE, title);
       values.put(Events.DESCRIPTION, description);
       values.put(Events.HAS_ALARM, 1);

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -438,7 +438,7 @@ public abstract class AbstractCalendarAccessor {
         values.put(Events.EVENT_TIMEZONE, TimeZone.getDefault().getID());
         values.put(Events.DTSTART, startTime);
         values.put(Events.DTEND, endTime);
-	  }
+      }
       values.put(Events.ALL_DAY, allDayEvent ? 1 : 0);
       values.put(Events.TITLE, title);
       values.put(Events.DESCRIPTION, description);


### PR DESCRIPTION
fixed #55 tested on a Nexus 5 (5.0.1), Motorola Bionic (4.1.2), and HTC EVO Design (4.02.651.2).  The only thing I noticed is when changing the example in issue #55 to +3 days for the end date, the event would be an all day event starting today and ending tomorrow; however, when editing the event the start date would be for the day before today.