### PR TITLE
Added interval option for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ demo/platforms
 demo/plugins
 *.ipr
 *.iml
+.idea/

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -216,9 +216,11 @@
       }
 
       NSString* recurrence = [newCalOptions objectForKey:@"recurrence"];
+      NSNumber* intervalAmount = [newCalOptions objectForKey:@"interval"];
+      
       if (recurrence != (id)[NSNull null]) {
         EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
-                                                                              interval: 1
+                                                                              interval: intervalAmount.integerValue
                                                                                    end: nil];
         NSString* recurrenceEndTime = [newCalOptions objectForKey:@"recurrenceEndTime"];
         if (recurrenceEndTime != nil) {
@@ -462,6 +464,7 @@
   NSString* recurrenceEndTime = [calOptions objectForKey:@"recurrenceEndTime"];
   NSString* calendarName = [calOptions objectForKey:@"calendarName"];
   NSString* url = [calOptions objectForKey:@"url"];
+  NSNumber* intervalAmount = [calOptions objectForKey:@"interval"];
 
   [self.commandDelegate runInBackground: ^{
     EKEvent *myEvent = [EKEvent eventWithEventStore: self.eventStore];
@@ -530,7 +533,7 @@
 
     if (recurrence != (id)[NSNull null]) {
       EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
-                                                                            interval: 1
+                                                                            interval: intervalAmount.integerValue
                                                                                  end: nil];
       if (recurrenceEndTime != nil) {
         NSTimeInterval _recurrenceEndTimeInterval = [recurrenceEndTime doubleValue] / 1000; // strip millis
@@ -569,6 +572,7 @@
   NSString* recurrenceEndTime = [calOptions objectForKey:@"recurrenceEndTime"];
   NSString* calendarName = [calOptions objectForKey:@"calendarName"];
   NSString* url = [calOptions objectForKey:@"url"];
+  NSNumber* intervalAmount = [calOptions objectForKey:@"interval"];
 
   EKEvent *myEvent = [EKEvent eventWithEventStore: self.eventStore];
   if (url != (id)[NSNull null]) {
@@ -628,7 +632,7 @@
     if (recurrence != (id)[NSNull null]) {
       [self.commandDelegate runInBackground: ^{
         EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
-                                                                              interval: 1
+                                                                              interval: intervalAmount.integerValue
                                                                                    end: nil];
         if (recurrenceEndTime != nil) {
           NSTimeInterval _recurrenceEndTimeInterval = [recurrenceEndTime doubleValue] / 1000; // strip millis

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -49,6 +49,7 @@ Calendar.prototype.getCalendarOptions = function () {
     firstReminderMinutes: 60,
     secondReminderMinutes: null,
     recurrence: null, // options are: 'daily', 'weekly', 'monthly', 'yearly'
+    interval: 1,
     recurrenceEndDate: null,
     calendarName: null,
     calendarId: null,


### PR DESCRIPTION
This adjustments adds an interval option for iOS. It corresponds with #180, and provides functionality for iOS to set a recurrence interval:

    var calOptions = window.plugins.calendar.getCalendarOptions(); // grab the defaults
    calOptions.interval = 28; // woohoo!!!

![screen shot 2015-07-21 at 16 26 25](https://cloud.githubusercontent.com/assets/346681/8803124/518714d2-2fc5-11e5-8189-7ec50697ef4b.png)

I hope to get it working for Android as well. I've never wrote Objective-C or Java before, but the changes are pretty small and straight-forward.