### PR TITLE
Stop listCalendars crashing on iOS 9 Beta

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -429,7 +429,7 @@
     NSArray * calendars = [self.eventStore calendarsForEntityType:EKEntityTypeEvent];
     NSMutableArray *finalResults = [[NSMutableArray alloc] initWithCapacity:calendars.count];
     for (EKCalendar *thisCalendar in calendars) {
-      NSString *type = [[NSArray arrayWithObjects:@"Local", @"CalDAV", @"Exchange", @"Subscription", @"Birthday", nil] objectAtIndex:thisCalendar.type];
+      NSString *type = [[NSArray arrayWithObjects:@"Local", @"CalDAV", @"Exchange", @"Subscription", @"Birthday", @"Mail", nil] objectAtIndex:thisCalendar.type];
       NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                     thisCalendar.calendarIdentifier, @"id",
                                     thisCalendar.title, @"name",


### PR DESCRIPTION
On IOS9, there is a newly added "Events found in Mail" calendar under "other". When performing listCalendars this crashes the app instantly (index out of bounds). This fix caters for the new "Mail" event type and returns it. There are probably more fixes needed to support this, but this removes a crash bug encountered during tests.