### PR TITLE
Add the calenderItemIdentifier to events using eventsToDataArray

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -403,7 +403,8 @@
       }
       [entry setObject:attendees forKey:@"attendees"];
     }
-      [entry setObject:event.eventIdentifier forKey:@"id"];
+    
+    [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -403,6 +403,7 @@
       }
       [entry setObject:attendees forKey:@"attendees"];
     }
+      [entry setObject:events.eventIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -403,7 +403,7 @@
       }
       [entry setObject:attendees forKey:@"attendees"];
     }
-      [entry setObject:events.eventIdentifier forKey:@"id"];
+      [entry setObject:event.eventIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;


### PR DESCRIPTION
I've needed an ID from iOS for a long while. I don't think this should affect anything else too much - it already exists in Android. 

While this ID can change if the event is moved from calendar to calendar, it is a least something to go off of. 