### PR TITLE
[iOS] implemented has[...]Permission + request[...]Access

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -924,9 +924,7 @@
 }
 
 -(CDVCommandStatus)requestCalendarAccess{
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
     [self initEventStoreWithCalendarCapabilities];
-    dispatch_semaphore_signal(sema);
     return (self.eventStore != nil) ? CDVCommandStatus_OK : CDVCommandStatus_ERROR;
 }
 


### PR DESCRIPTION
Implemented the explicit permission-handling methods for iOS.

This may need additional testing because of a bugfix included in this commit. The fix may have side-effects.

In detail:
In the `initEventStoreWithCalendarCapabilities` method the eventStore object got assigned to the instance-variable even if access had been denied. This was due to the fact that the candidate variable was missing its declaration, so it got assigned to the instance variable immediately instead of in the if-clause body.