### PR TITLE
fix for allday event

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -314,13 +314,23 @@ public class Calendar extends CordovaPlugin {
       cordova.getThreadPool().execute(new Runnable() {
         @Override
         public void run() {
+          final boolean isAllDayEvent = AbstractCalendarAccessor.isAllDayEvent(new Date(jsonFilter.optLong("startTime")), new Date(jsonFilter.optLong("endTime")));
           final Intent calIntent = new Intent(Intent.ACTION_EDIT)
               .setType("vnd.android.cursor.item/event")
               .putExtra("title", getPossibleNullString("title", jsonFilter))
-              .putExtra("beginTime", jsonFilter.optLong("startTime") + TimeZone.getDefault().getOffset(jsonFilter.optLong("startTime")))
-              .putExtra("endTime", jsonFilter.optLong("endTime") + TimeZone.getDefault().getOffset(jsonFilter.optLong("endTime")))
-              .putExtra("hasAlarm", 1)
-              .putExtra("allDay", AbstractCalendarAccessor.isAllDayEvent(new Date(jsonFilter.optLong("startTime")), new Date(jsonFilter.optLong("endTime"))));
+              .putExtra("hasAlarm", 1);
+          if(isAllDayEvent){
+            calIntent
+                .putExtra("allDay", isAllDayEvent)
+                .putExtra("beginTime", jsonFilter.optLong("startTime") + TimeZone.getDefault().getOffset(jsonFilter.optLong("startTime")))
+                .putExtra("endTime", jsonFilter.optLong("endTime") + TimeZone.getDefault().getOffset(jsonFilter.optLong("endTime")))
+                .putExtra("eventTimezone", "TIMEZONE_UTC");
+          } else {
+            calIntent
+                .putExtra("beginTime", jsonFilter.optLong("startTime"))
+                .putExtra("endTime", jsonFilter.optLong("endTime"));
+          }
+
           // TODO can we pass a reminder here?
 
           // optional fields


### PR DESCRIPTION
this patch fixes a bug with the previous allday Event fix, that caused times to be incorrect if allday was not selected