### PR TITLE
Retrieve more info for Recurring Events

### DIFF
--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -585,7 +585,7 @@ public class Calendar extends CordovaPlugin {
           calendar_end.setTime(date_end);
 
           //projection of DB columns
-          String[] l_projection = new String[]{"calendar_id", "title", "begin", "end", "eventLocation", "allDay", "_id", "rrule", "rdate", "exdate"};
+          String[] l_projection = new String[]{"calendar_id", "title", "begin", "end", "eventLocation", "allDay", "_id", "rrule", "rdate", "exdate", "event_id"};
 
           //actual query
           Cursor cursor = contentResolver.query(
@@ -610,7 +610,8 @@ public class Calendar extends CordovaPlugin {
                     i++,
                     new JSONObject()
                         .put("calendar_id", cursor.getString(cursor.getColumnIndex("calendar_id")))
-                        .put("event_id", cursor.getString(cursor.getColumnIndex("_id")))
+                        .put("id", cursor.getString(cursor.getColumnIndex("_id")))
+                        .put("event_id", cursor.getString(cursor.getColumnIndex("event_id")))
                         .put("rrule", cursor.getString(cursor.getColumnIndex("rrule")))
                         .put("rdate", cursor.getString(cursor.getColumnIndex("rdate")))
                         .put("exdate", cursor.getString(cursor.getColumnIndex("exdate")))

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -585,7 +585,7 @@ public class Calendar extends CordovaPlugin {
           calendar_end.setTime(date_end);
 
           //projection of DB columns
-          String[] l_projection = new String[]{"calendar_id", "title", "begin", "end", "eventLocation", "allDay", "_id"};
+          String[] l_projection = new String[]{"calendar_id", "title", "begin", "end", "eventLocation", "allDay", "_id", "rrule", "rdate", "exdate"};
 
           //actual query
           Cursor cursor = contentResolver.query(
@@ -611,6 +611,9 @@ public class Calendar extends CordovaPlugin {
                     new JSONObject()
                         .put("calendar_id", cursor.getString(cursor.getColumnIndex("calendar_id")))
                         .put("event_id", cursor.getString(cursor.getColumnIndex("_id")))
+                        .put("rrule", cursor.getString(cursor.getColumnIndex("rrule")))
+                        .put("rdate", cursor.getString(cursor.getColumnIndex("rdate")))
+                        .put("exdate", cursor.getString(cursor.getColumnIndex("exdate")))
                         .put("title", cursor.getString(cursor.getColumnIndex("title")))
                         .put("dtstart", cursor.getLong(cursor.getColumnIndex("begin")))
                         .put("dtend", cursor.getLong(cursor.getColumnIndex("end")))

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -407,7 +407,9 @@
       [entry setObject:attendees forKey:@"attendees"];
     }
 
-    
+    if (event.recurrenceRules != nil) {
+      [entry setObject:event.recurrenceRules forKey:@"rrule"];
+    }
 
     [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -28,7 +28,7 @@
   } else { // we're on iOS 5 or older
     accessGranted = YES;
   }
-    
+
   if (accessGranted) {
     self.eventStore = eventStoreCandidate;
   }
@@ -375,6 +375,7 @@
     NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                   event.title, @"title",
                                   event.calendar.title, @"calendar",
+                                  event.eventIdentifier, @"id",
                                   [df stringFromDate:event.startDate], @"startDate",
                                   [df stringFromDate:event.endDate], @"endDate",
                                   [df stringFromDate:event.lastModifiedDate], @"lastModifiedDate",
@@ -405,6 +406,8 @@
       }
       [entry setObject:attendees forKey:@"attendees"];
     }
+
+    
 
     [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];


### PR DESCRIPTION
**1. 	Added Support for Recurring Events in listEventsInRange for Android**

This adds more info per event like: `rrule`, `rdate`, `exdate`

**2. 	Added Event Id per Row and per column in listEventsInRange for Android**

I've now included ID per column, so it returns two ids: per ROW ("`id`") and per COLUMN ("`event_id`"), the difference is:

- When Creating Recurring Event, all instances have two ids, one unique id per instance ("`id`") and one id shared across all instances ("`event_id`") at my work (Calendar App) we create one Recurring event and then create instances of it, so I'm guessing lots of developers would like to get the ID per instance and the shared ID