### PR TITLE
Return more Recurring Data per event on iOS

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -411,7 +411,50 @@
     }
 
     if (event.recurrenceRules != nil) {
-//      [entry setObject:event.recurrenceRules forKey:@"rrule"];
+      for (EKRecurrenceRule *rule in event.recurrenceRules) {
+        NSMutableDictionary *rrule = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
+            rule.calendarIdentifier, @"calendar", nil];
+
+        switch (rule.frequency) {
+          case EKRecurrenceFrequencyDaily:
+              [rrule setObject:@"daily" forKey:@"freq"];
+          break;
+
+          case EKRecurrenceFrequencyWeekly:
+              [rrule setObject:@"weekly" forKey:@"freq"];
+          break;
+
+          case EKRecurrenceFrequencyMonthly:
+              [rrule setObject:@"monthly" forKey:@"freq"];
+          break;
+
+          case EKRecurrenceFrequencyYearly:
+              [rrule setObject:@"yearly" forKey:@"freq"];
+          break;
+
+          default:
+              [rrule setObject:@"none" forKey:@"freq"];
+          break;
+        }
+
+        NSNumber *interval = [NSNumber numberWithInteger: rule.interval];
+        [rrule setObject:interval forKey:@"interval"];
+
+      if (rule.recurrenceEnd != nil) {
+        NSMutableDictionary *until = [[NSMutableDictionary alloc] init];
+
+        if (rule.recurrenceEnd.endDate != nil) {
+          [until setObject:[df stringFromDate:rule.recurrenceEnd.endDate] forKey:@"date"];
+        }
+
+      NSNumber *count = [NSNumber numberWithInteger: rule.recurrenceEnd.occurrenceCount];
+      [until setObject:count forKey:@"count"];
+
+        [rrule setObject:until forKey:@"until"];
+      }
+
+        [entry setObject:rrule forKey:@"rrule"];
+      }
     }
 
     [entry setObject:event.calendarItemIdentifier forKey:@"id"];


### PR DESCRIPTION
Now also on iOS like a did for Android, when listing events it will return more data for recurring events like:

- rrule (Object containing Recurring Data)
- calendar (the calendar type in which is the recurring event)
- freq (Repeating Frequency: daily, weekly, monthly, yearly)
- interval (Repeating interval, for example: every 2 week, every 3 days and etc.)
- until (Object containing End Data)
- date (End Date)
- count (how much times to repeat the event)

Example:

![screen shot 2016-11-28 at 13 40 16](https://cloud.githubusercontent.com/assets/9529847/20668737/acbe27f0-b570-11e6-92f8-3bef8898c6f6.png)
