### PR TITLE
Support search using calendarIdentifier

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -345,6 +345,9 @@
       if ([thisCalendar.title isEqualToString:calendarName]) {
         return thisCalendar;
       }
+      if ([thisCalendar.calendarIdentifier isEqualToString:calendarName]) {
+        return thisCalendar;
+      }
     }
   }
   NSLog(@"No match found for calendar with name: %@", calendarName);


### PR DESCRIPTION
Exchange based calendars have the problem that you can't change their names. If you happen to have 2 exchange accounts on your iOS device you can only address one calendar since both of those calendars will have the name "Calendar". The current implementation will select the first one matching the name.

Since you already return the id of the calendars, the implementation could pass in that id to find the calendar again. To remain backward compatible and don't introduce a interface bloat here, I kept it simple and checked the calendarIdentifier against the passed in name as well. So in theory, you can pass in either now.