### PR TITLE
Remove cordova-plugin-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-calendar",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "This plugin allows you to manipulate the native calendar.",
   "cordova": {
     "id": "cordova-plugin-calendar",
@@ -21,12 +21,13 @@
     "cordova-ios",
     "cordova-android"
   ],
-  "engines": [
-    {
-      "name": "cordova",
-      "version": ">=3.0.0"
+  "engines": {
+    "cordovaDependencies": {
+      "3.0.0": {
+        "cordova-android": ">=6.3.0"
+      }
     }
-  ],
+  },
   "author": "Eddy Verbruggen <eddyverbruggen@gmail.com> (https://github.com/EddyVerbruggen)",
   "license": "MIT",
   "bugs": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
     xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-calendar"
-    version="4.6.0">
+    version="4.6.1">
 
   <name>Calendar</name>
 
@@ -22,7 +22,7 @@
   <issue>https://github.com/EddyVerbruggen/Calendar-PhoneGap-Plugin/issues</issue>
 
   <engines>
-    <engine name="cordova" version=">=3.0.0"/>
+      <engine name="cordova-android" version=">=6.3.0" />
   </engines>
 
   <js-module src="www/Calendar.js" name="Calendar">
@@ -78,7 +78,6 @@
                  target-dir="src/nl/xservices/plugins/accessor"/>
     <source-file src="src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java"
                  target-dir="src/nl/xservices/plugins/accessor"/>
-    <dependency id="cordova-plugin-compat" version="^1.0.0" />
   </platform>
   
   <!-- windows -->


### PR DESCRIPTION
`cordova-plugin-compat` is now deprecated and integrated into `cordova-android`, therefore the dependency could be removed

this PR is linked with following issue: https://github.com/EddyVerbruggen/Calendar-PhoneGap-Plugin/issues/426

cordova release notes: https://cordova.apache.org/news/2017/11/10/plugins-release.html

I tried to remove the dependency the same way as cordova did in `cordova-plugin-contacts` or `cordova-plugin-camera`, I hope you will think it's ok

P.S.: I also pushed up the version number of the plugin, don't know if it's what you would except, just thought better to push up the version than submitting a PR with same version number