### PR TITLE
refactor: merge two assignments of "id" property, to reduce confusion

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -381,7 +381,7 @@
     NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                   event.title, @"title",
                                   event.calendar.title, @"calendar",
-                                  event.eventIdentifier, @"id",
+                                  event.calendarItemIdentifier , @"id",
                                   [df stringFromDate:event.startDate], @"startDate",
                                   [df stringFromDate:event.endDate], @"endDate",
                                   [df stringFromDate:event.lastModifiedDate], @"lastModifiedDate",
@@ -460,7 +460,6 @@
       }
     }
 
-    [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;


### PR DESCRIPTION
I have noticed that two different identifiers are copied into the `id` property while fetching events in iOS. The end result is correct and consistent, but a bit confusing to read. This change removes the misleading duplicate and inits just once, without altering behavior.