### PR TITLE
Delete recurring

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ modifyEvent                         |             | yes |         |         |
 modifyEventWithOptions              |             | yes |         |         |
 deleteEvent                         |             | yes | yes     |         |
 deleteEventFromNamedCalendar        |             | yes |         |         |
+deleteEventById                     |             | yes | yes     |         |
 openCalendar                        |             | yes | yes     |         |
 
 * \* on Android < 4 dialog is shown
@@ -247,6 +248,9 @@ Basic operations, you'll want to copy-paste this for testing purposes:
 
   // delete an event, as above, but for a specific calendar (iOS only)
   window.plugins.calendar.deleteEventFromNamedCalendar(newTitle,eventLocation,notes,startDate,endDate,calendarName,success,error);
+
+  // delete an event by id. If the event has recurring instances, all will be deleted unless `fromDate` is specified, which will delete from that date onward. (iOS and android only)
+  window.plugins.calendar.deleteEventById(id,fromDate,success,error);
 
   // open the calendar app (added in 4.2.8):
   // - open it at 'today'

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -398,8 +398,7 @@ public class Calendar extends CordovaPlugin {
             if (recurrenceEndTime == null) {
               calIntent.putExtra(Events.RRULE, "FREQ=" + recurrence.toUpperCase() + ";INTERVAL=" + recurrenceInterval);
             } else {
-              final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd'T'hhmmss'Z'");
-              calIntent.putExtra(Events.RRULE, "FREQ=" + recurrence.toUpperCase() + ";INTERVAL=" + recurrenceInterval + ";UNTIL=" + sdf.format(new Date(recurrenceEndTime)));
+              calIntent.putExtra(Events.RRULE, "FREQ=" + recurrence.toUpperCase() + ";INTERVAL=" + recurrenceInterval + ";UNTIL=" + formatICalDateTime(new Date(recurrenceEndTime)));
             }
           }
 
@@ -667,5 +666,11 @@ public class Calendar extends CordovaPlugin {
       Log.d(LOG_TAG, "onActivityResult error, resultcode: " + resultCode);
       callback.error("Unable to add event (" + resultCode + ").");
     }
+  }
+
+  public static String formatICalDateTime(Date date) {
+    final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return sdf.format(date);
   }
 }

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -43,6 +43,7 @@ public class Calendar extends CordovaPlugin {
   private static final String ACTION_CREATE_EVENT_WITH_OPTIONS = "createEventWithOptions";
   private static final String ACTION_CREATE_EVENT_INTERACTIVELY = "createEventInteractively";
   private static final String ACTION_DELETE_EVENT = "deleteEvent";
+  private static final String ACTION_DELETE_EVENT_BY_ID = "deleteEventById";
   private static final String ACTION_FIND_EVENT_WITH_OPTIONS = "findEventWithOptions";
   private static final String ACTION_LIST_EVENTS_IN_RANGE = "listEventsInRange";
   private static final String ACTION_LIST_CALENDARS = "listCalendars";
@@ -54,6 +55,7 @@ public class Calendar extends CordovaPlugin {
   private static final int PERMISSION_REQCODE_DELETE_CALENDAR = 101;
   private static final int PERMISSION_REQCODE_CREATE_EVENT = 102;
   private static final int PERMISSION_REQCODE_DELETE_EVENT = 103;
+  private static final int PERMISSION_REQCODE_DELETE_EVENT_BY_ID = 104;
 
   // read permissions
   private static final int PERMISSION_REQCODE_FIND_EVENTS = 200;
@@ -101,6 +103,9 @@ public class Calendar extends CordovaPlugin {
       return true;
     } else if (!hasLimitedSupport && ACTION_DELETE_EVENT.equals(action)) {
       deleteEvent(args);
+      return true;
+    } else if (!hasLimitedSupport && ACTION_DELETE_EVENT_BY_ID.equals(action)) {
+      deleteEventById(args);
       return true;
     } else if (ACTION_LIST_CALENDARS.equals(action)) {
       listCalendars();
@@ -196,6 +201,8 @@ public class Calendar extends CordovaPlugin {
       createEvent(requestArgs);
     } else if (requestCode == PERMISSION_REQCODE_DELETE_EVENT) {
       deleteEvent(requestArgs);
+    } else if (requestCode == PERMISSION_REQCODE_DELETE_EVENT_BY_ID) {
+      deleteEventById(requestArgs);
     } else if (requestCode == PERMISSION_REQCODE_FIND_EVENTS) {
       findEvents(requestArgs);
     } else if (requestCode == PERMISSION_REQCODE_LIST_CALENDARS) {
@@ -461,6 +468,31 @@ public class Calendar extends CordovaPlugin {
       System.err.println("Exception: " + e.getMessage());
       callback.error(e.getMessage());
     }
+  }
+
+  private void deleteEventById(final JSONArray args) {
+
+    // note that if the dev didn't call requestWritePermission before calling this method and calendarPermissionGranted returns false,
+    // the app will ask permission and this method needs to be invoked again (done for backward compat).
+    if (!calendarPermissionGranted(Manifest.permission.WRITE_CALENDAR)) {
+      requestWritePermission(PERMISSION_REQCODE_DELETE_EVENT_BY_ID);
+      return;
+    }
+
+    cordova.getThreadPool().execute(new Runnable() { @Override public void run() {
+      try {
+        final JSONObject opts = args.optJSONObject(0);
+        final long id = opts != null ? opts.optLong("id", -1) : -1;
+        final long fromTime =  opts != null ? opts.optLong("fromTime", -1) : -1;
+
+        boolean deleteResult = getCalendarAccessor().deleteEventById(null, id, fromTime);
+
+        callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, deleteResult));
+      } catch (Exception e) {
+        System.err.println("Exception: " + e.getMessage());
+        callback.error(e.getMessage());
+      }
+    }});
   }
 
   private void findEvents(JSONArray args) {

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -543,14 +543,12 @@ public abstract class AbstractCalendarAccessor {
         values.put(Events.EVENT_LOCATION, location);
 
         if (recurrence != null) {
-            final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd'T'hhmmss'Z'");
-
             String rrule = "FREQ=" + recurrence.toUpperCase() +
                     ((recurrenceInterval > -1) ? ";INTERVAL=" + recurrenceInterval : "") +
                     ((recurrenceWeekstart != null) ? ";WKST=" + recurrenceWeekstart : "") +
                     ((recurrenceByDay != null) ? ";BYDAY=" + recurrenceByDay : "") +
                     ((recurrenceByMonthDay != null) ? ";BYMONTHDAY=" + recurrenceByMonthDay : "") +
-                    ((recurrenceEndTime > -1) ? ";UNTIL=" + sdf.format(new Date(recurrenceEndTime)) : "") +
+                    ((recurrenceEndTime > -1) ? ";UNTIL=" + nl.xservices.plugins.Calendar.formatICalDateTime(new Date(recurrenceEndTime)) : "") +
                     ((recurrenceCount > -1) ? ";COUNT=" + recurrenceCount : "");
             values.put(Events.RRULE, rrule);
         }

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -541,8 +541,10 @@ public abstract class AbstractCalendarAccessor {
         // Find target instance
         long targDtStart = -1;
         {
+            // Scans just over a year.
+            // Not using a wider range because it can corrupt the Calendar Storage state! https://issuetracker.google.com/issues/36980229
             Cursor cur = queryEventInstances(fromTime,
-                                             Long.MAX_VALUE,
+                                             fromTime + 1000L * 60L * 60L * 24L * 367L,
                                              new String[] { Instances.DTSTART },
                                              Instances.EVENT_ID + " = ?",
                                              new String[] { Long.toString(id) },

--- a/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
@@ -89,6 +89,12 @@ public class CalendarProviderAccessor extends AbstractCalendarAccessor {
   }
 
   @Override
+  public boolean deleteEventById(Uri eventsUri, long id, long fromDate) {
+    eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
+    return super.deleteEventById(eventsUri, id, fromDate);
+  }
+
+  @Override
   public String createEvent(Uri eventsUri, String title, long startTime, long endTime,
                             String description, String location, Long firstReminderMinutes, Long secondReminderMinutes,
                             String recurrence, int recurrenceInterval, String recurrenceWeekstart,

--- a/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
@@ -91,6 +91,12 @@ public class LegacyCalendarAccessor extends AbstractCalendarAccessor {
   }
 
   @Override
+  public boolean deleteEventById(Uri eventsUri, long id, long fromDate) {
+    eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER_PRE_FROYO + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
+    return super.deleteEventById(eventsUri, id, fromDate);
+  }
+
+  @Override
   public String createEvent(Uri eventsUri, String title, long startTime, long endTime,
                             String description, String location, Long firstReminderMinutes, Long secondReminderMinutes,
                             String recurrence, int recurrenceInterval, String recurrenceWeekstart,

--- a/src/ios/Calendar.h
+++ b/src/ios/Calendar.h
@@ -41,6 +41,7 @@
 - (void)deleteEvent:(CDVInvokedUrlCommand*)command;
 - (void)deleteEventFromNamedCalendar:(CDVInvokedUrlCommand*)command;
 - (void)deleteEventFromCalendar:(CDVInvokedUrlCommand*)command calendar:(EKCalendar*)calendar;
+- (void)deleteEventById:(CDVInvokedUrlCommand*)command;
 - (void)eventEditViewController:(EKEventEditViewController*)controller didCompleteWithAction:(EKEventEditViewAction) action;
 
 @end

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -773,6 +773,57 @@
   }
 }
 
+- (void) deleteEventById:(CDVInvokedUrlCommand*)command {
+  NSDictionary* options = [command.arguments objectAtIndex:0];
+  NSString* ciid = [options objectForKey:@"id"];
+  NSNumber* fromTime = [options objectForKey:@"fromTime"];
+
+  [self.commandDelegate runInBackground: ^{
+
+    // Get original instance
+    EKEvent* firstEvent = (EKEvent *)[eventStore calendarItemWithIdentifier:ciid];
+    if (firstEvent == nil) {
+      // Fail
+      [self.commandDelegate
+        sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Could not find event."]
+        callbackId:command.callbackId];
+      return;
+    } else {
+      EKEvent* instance;
+      if (fromTime != nil && fromTime != (id)NSNull.null) {
+        // Find target instance
+        NSDate* fromDate = [NSDate dateWithTimeIntervalSince1970:(fromTime.doubleValue / 1000)]; // strip millis
+        NSArray<EKEvent*>* toDelete = [eventStore eventsMatchingPredicate:[eventStore predicateForEventsWithStartDate:fromDate endDate:NSDate.distantFuture calendars:@[firstEvent.calendar]]];
+        if (toDelete.count < 1) {
+          // Nothing to delete
+          [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+          return;
+        }
+        NSArray<EKEvent*>* toDeleteSorted = [toDelete sortedArrayUsingSelector:@selector(compareStartDateWithEvent:)];
+        instance = toDeleteSorted.firstObject;
+      } else {
+        // First instance is target
+        instance = firstEvent;
+      }
+
+      // Delete
+      NSError *error = nil;
+      [eventStore removeEvent:instance span:EKSpanFutureEvents error:&error];
+      if (error != nil) {
+        // Fail
+        [self.commandDelegate
+          sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Could not delete event."]
+          callbackId:command.callbackId];
+        return;
+      } else {
+        // Succeed
+        [self.commandDelegate sendPluginResult:[CDVPluginResult resultWithStatus:CDVCommandStatus_OK] callbackId:command.callbackId];
+        return;
+      }
+    }
+  }];
+}
+
 - (void) findAllEventsInNamedCalendar:(CDVInvokedUrlCommand*)command {
   NSDictionary* options = [command.arguments objectAtIndex:0];
   NSString* calendarName = [options objectForKey:@"calendarName"];

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -381,7 +381,7 @@
     NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                   event.title, @"title",
                                   event.calendar.title, @"calendar",
-                                  event.eventIdentifier, @"id",
+                                  event.calendarItemIdentifier , @"id",
                                   [df stringFromDate:event.startDate], @"startDate",
                                   [df stringFromDate:event.endDate], @"endDate",
                                   [df stringFromDate:event.lastModifiedDate], @"lastModifiedDate",
@@ -460,7 +460,6 @@
       }
     }
 
-    [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cordova-plugin-calendar-tests",
+  "version": "5.0.0",
+  "description": "",
+  "cordova": {
+    "id": "cordova-plugin-calendar-tests",
+    "platforms": []
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "author": "",
+  "license": "Apache 2.0"
+}

--- a/test/plugin.xml
+++ b/test/plugin.xml
@@ -28,4 +28,17 @@
 
     <js-module src="tests.js" name="tests">
     </js-module>
+
+    <platform name="android">
+      <config-file target="res/xml/config.xml" parent="/*">
+        <feature name="CalendarTestsUtility">
+          <param name="android-package" value="org.apache.cordova.calendartests.Utility"/>
+        </feature>
+      </config-file>
+      <config-file target="AndroidManifest.xml" parent="/manifest">
+        <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+        <uses-permission android:name="android.permission.READ_SYNC_STATS"/>
+      </config-file>
+      <source-file src="src/android/org/apache/cordova/calendartests/Utility.java" target-dir="src/org/apache/cordova/calendartests"/>
+    </platform>
 </plugin>

--- a/test/plugin.xml
+++ b/test/plugin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="cordova-plugin-calendar-tests"
+    version="5.0.0">
+    <name>Cordova Calendar Plugin Tests</name>
+    <license>Apache 2.0</license>
+
+    <js-module src="tests.js" name="tests">
+    </js-module>
+</plugin>

--- a/test/src/android/org/apache/cordova/calendartests/Utility.java
+++ b/test/src/android/org/apache/cordova/calendartests/Utility.java
@@ -1,0 +1,46 @@
+package org.apache.cordova.calendartests;
+
+import android.content.ContentResolver;
+import android.os.Bundle;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
+import org.apache.cordova.PluginResult;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+public class Utility extends CordovaPlugin {
+
+  private CallbackContext callback;
+
+  @Override
+  public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
+    this.callback = callbackContext;
+
+    if ("syncAndroidGoogleCalendar".equals(action)) {
+      syncAndroidGoogleCalendar();
+      return true;
+    }
+    return false;
+  }
+
+  private void syncAndroidGoogleCalendar() {
+    cordova.getThreadPool().execute(new Runnable() { @Override public void run() {
+      String authority = "com.android.calendar";
+
+      Bundle settingsBundle = new Bundle();
+      settingsBundle.putBoolean(ContentResolver.SYNC_EXTRAS_MANUAL, true);
+      settingsBundle.putBoolean(ContentResolver.SYNC_EXTRAS_EXPEDITED, true);
+      for (android.accounts.Account acc : android.accounts.AccountManager.get(cordova.getActivity()).getAccountsByType("com.google")) {
+        ContentResolver.requestSync(acc, authority, settingsBundle);
+
+        // Wait for completion
+        try { Thread.sleep(1000); } catch (InterruptedException e) {}
+        int ii = 0;
+        while (++ii < 30 && ContentResolver.isSyncActive(acc, authority)) {
+          try { Thread.sleep(1000); } catch (InterruptedException e) {}
+        }
+      }
+      callback.sendPluginResult(new PluginResult(PluginResult.Status.OK));
+    }});
+  }
+}

--- a/test/tests.js
+++ b/test/tests.js
@@ -86,6 +86,58 @@ exports.defineAutoTests = function() {
             });
         });
     });
+
+    itP('should support delete by title or date', function () {
+      var title = 'DF event' + runTag + ' ';
+      var first, bytitle, bydate, last;
+
+      // create
+      return createEventP(title + 'first', null, null, newDate(1, 7), newDate(1, 8))
+        .then(function (id) {
+          first = id;
+          return createEventP(title + 'bytitle', null, null, newDate(1, 9), newDate(1, 10));
+        })
+        .then(function (id) {
+          bytitle = id;
+          return createEventP(title + 'bydate', null, null, newDate(1, 11), newDate(1, 13));
+        })
+        .then(function (id) {
+          bydate = id;
+          return createEventP(title + 'last', null, null, newDate(1, 14), newDate(1, 15));
+        })
+        .then(function (id) {
+          last = id;
+
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.length).toBe(4);
+
+          // delete by title
+          return deleteEventP(title + 'bytitle', null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.map(function (e) { return e.id; })).toEqual([first, bydate, last]);
+
+          // delete by date
+          return deleteEventP(null, null, null, newDate(1, 11), newDate(1, 13));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.map(function (e) { return e.id; })).toEqual([first, last]);
+
+          // delete the rest
+          return deleteEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        });
+    });
   });
 
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -74,6 +74,10 @@ exports.defineAutoTests = function() {
     });
   });
 
+  // subsequent tests cover functionality specific to iOS and android
+  if (cordova.platformId != 'android' && cordova.platformId != 'ios')
+    return;
+
   describe('createEvent / findEvent / deleteEvent', function () {
     itP('should create, find, then delete an event', function () {
       var title = 'CFD event' + runTag;
@@ -244,39 +248,41 @@ exports.defineAutoTests = function() {
         });
     });
 
-    itP('should support truncating recurrences defined by a count', function() {
-      var title = 'delIdCtDate event' + runTag;
+    if (cordova.platformId == 'android') {
+      itP('should support truncating recurrences defined by a count in android', function() {
+        var title = 'delIdCtDate event' + runTag;
 
-      return createRecurring(title, true)
-        .then(function (id) {
-          return deleteEventByIdP(id, newDate(4, 18));
-        })
-        .then(function () {
-          return syncAndroidGoogleCalendarP();
-        })
-        .then(function () {
-          return findEventP(title, null, null, newDate(2, 0), newDate(8, 0));
-        })
-        .then(function (events) {
-          expect(events.length).toBe(2);
-          expect(parseEventDate(events[1].startDate)).toEqual(newDate(3, 18));
-        });
-    });
+        return createRecurring(title, true)
+          .then(function (id) {
+            return deleteEventByIdP(id, newDate(4, 18));
+          })
+          .then(function () {
+            return syncAndroidGoogleCalendarP();
+          })
+          .then(function () {
+            return findEventP(title, null, null, newDate(2, 0), newDate(8, 0));
+          })
+          .then(function (events) {
+            expect(events.length).toBe(2);
+            expect(parseEventDate(events[1].startDate)).toEqual(newDate(3, 18));
+          });
+      });
 
-    itP('should succeed if already truncated by a count', function () {
-      var title = 'delIdCtAgain event' + runTag;
+      itP('should succeed if already truncated by a count in android', function () {
+        var title = 'delIdCtAgain event' + runTag;
 
-      return createRecurring(title, true)
-        .then(function (id) {
-          return deleteEventByIdP(id, newDate(5, 19));
-        })
-        .then(function () {
-          return findEventP(title, null, null, newDate(2, 0), newDate(8, 0));
-        })
-        .then(function (events) {
-          expect(events.length).toBe(4);
-        });
-    });
+        return createRecurring(title, true)
+          .then(function (id) {
+            return deleteEventByIdP(id, newDate(5, 19));
+          })
+          .then(function () {
+            return findEventP(title, null, null, newDate(2, 0), newDate(8, 0));
+          })
+          .then(function (events) {
+            expect(events.length).toBe(4);
+          });
+      });
+    };
   });
 
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,14 +1,5 @@
 exports.defineAutoTests = function() {
   
-  var fail = function (done) {
-    expect(true).toBe(false);
-    done();
-  },
-  succeed = function (done) {
-    expect(true).toBe(true);
-    done();
-  };
-
   describe('Plugin availability', function () {
     it("window.plugins.calendar should exist", function() {
       expect(window.plugins.calendar).toBeDefined();
@@ -20,17 +11,4 @@ exports.defineAutoTests = function() {
       expect(window.plugins.calendar.createEventWithOptions).toBeDefined();
     });
   });
-
-  /*
-  TODO extend - this is a copy-paste example of Toast
-  describe('Invalid usage', function () {
-    it("should fail due to an invalid position", function(done) {
-     window.plugins.toast.show('hi', 'short', 'nowhere', fail.bind(null, done), succeed.bind(null, done));
-    });
-
-    it("should fail due to an invalid duration", function(done) {
-     window.plugins.toast.show('hi', 'medium', 'top', fail.bind(null, done), succeed.bind(null, done));
-    });
-  });
-  */
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -18,12 +18,16 @@ exports.defineAutoTests = function() {
     });
   };
   var promisifyScbEcb = function (func) {
-    if (typeof(func) != 'function')
+    if (typeof (func) != 'function')
       throw 'not a function: ' + func;
     return function () {
-      var args = arguments;
+      var args = Array.prototype.slice.call(arguments);
+      if (args.length > func.length - 2)
+        throw 'too many arguments; expected at most ' + func.length - 2;
       return new Promise(function (resolve, reject) {
-        func.apply(null, Array.prototype.slice.call(args).concat(resolve, reject));
+        args[func.length - 2] = resolve;
+        args[func.length - 1] = reject;
+        func.apply(null, args);
       });
     };
   };
@@ -193,7 +197,7 @@ exports.defineAutoTests = function() {
 
       return createRecurring(title)
         .then(function (id) {
-          return deleteEventByIdP(id, null);
+          return deleteEventByIdP(id);
         })
         .then(function () {
           return findEventP(title, null, null, newDate(2, 0), newDate(8, 0));
@@ -224,7 +228,7 @@ exports.defineAutoTests = function() {
 
     itP('should fail on invalid id', function () {
       var failed = false;
-      return deleteEventByIdP('3826806B-1678-46DE-96B5-0748014AD920', null)
+      return deleteEventByIdP('3826806B-1678-46DE-96B5-0748014AD920')
         .catch(function () {
           failed = true;
         })

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,51 @@
 exports.defineAutoTests = function() {
   
+  var itP = function (description, fn, timeout) {
+    it(description, function (done) {
+      Promise.resolve(fn())
+        .catch(fail)
+        .then(done, done);
+    }, timeout);
+  };
+
+  var runTime = new Date();
+  var runId = Math.floor((runTime - new Date(runTime).setHours(0, 0, 0, 0)) / 1000);
+  var runTag = ' [cpctZQX' + runId + ']';
+
+  var promisifyScbEcb = function (func) {
+    if (typeof(func) != 'function')
+      throw 'not a function: ' + func;
+    return function () {
+      var args = arguments;
+      return new Promise(function (resolve, reject) {
+        func.apply(null, Array.prototype.slice.call(args).concat(resolve, reject));
+      });
+    };
+  };
+  var deleteEventP = promisifyScbEcb(plugins.calendar.deleteEvent);
+  var findEventP = promisifyScbEcb(plugins.calendar.findEvent);
+  var createEventP = promisifyScbEcb(plugins.calendar.createEvent);
+  var parseEventDate = plugins.calendar.parseEventDate;
+
+  var newDate = function (dd, hh, mm) {
+    return new Date(2018, 0, 21 + dd, hh || 0, mm || 0);
+  };
+
+
+  beforeEach(function (done) {
+    /* clean up autotest data */
+    return deleteEventP('[cpctZQX', null, null, newDate(1), newDate(8))
+      .then(function () {
+        return findEventP(runTag, null, null, newDate(1), newDate(8));
+      })
+      .then(function (events) {
+        expect(events.length).toBe(0, 'if test data was cleaned up');
+      })
+      .catch(fail)
+      .then(done, done);
+  });
+
+
   describe('Plugin availability', function () {
     it("window.plugins.calendar should exist", function() {
       expect(window.plugins.calendar).toBeDefined();
@@ -11,4 +57,35 @@ exports.defineAutoTests = function() {
       expect(window.plugins.calendar.createEventWithOptions).toBeDefined();
     });
   });
+
+  describe('createEvent / findEvent / deleteEvent', function () {
+    itP('should create, find, then delete an event', function () {
+      var title = 'CFD event' + runTag;
+
+      // create
+      return createEventP(title, null, null, newDate(2, 18), newDate(2, 19))
+        .then(function (id) {
+          // find
+          return findEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+            .then(function (events) {
+              expect(events.length).toBe(1);
+              expect(events[0].title).toBe(title);
+              expect(parseEventDate(events[0].startDate)).toEqual(newDate(2, 18));
+              expect(parseEventDate(events[0].endDate)).toEqual(newDate(2, 19));
+              expect(events[0].id).toBe(id);
+            });
+        })
+        .then(function () {
+          // delete
+          return deleteEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+            .then(function () {
+              return findEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+                .then(function (events) {
+                  expect(events.length).toBe(0);
+                });
+            });
+        });
+    });
+  });
+
 };

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -270,6 +270,14 @@ Calendar.prototype.listCalendars = function (successCallback, errorCallback) {
   cordova.exec(successCallback, errorCallback, "Calendar", "listCalendars", []);
 };
 
+Calendar.prototype.parseEventDate = function (dateStr) {
+	var spl;
+	// Handle yyyy-MM-dd HH:mm:ss format returned by AbstractCalendarAccessor.java L66, Calendar.m L378, and most similar formats
+	return (spl = /^\s*(\d{4})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\s*$/.exec(dateStr))
+		&& new Date(spl[1], spl[2] - 1, spl[3], spl[4], spl[5], spl[6])
+		|| new Date(dateStr);
+};
+
 Calendar.install = function () {
   if (!window.plugins) {
     window.plugins = {};

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -208,6 +208,13 @@ Calendar.prototype.deleteEventFromNamedCalendar = function (title, location, not
   }])
 };
 
+Calendar.prototype.deleteEventById = function (id, fromDate, successCallback, errorCallback) {
+  cordova.exec(successCallback, errorCallback, "Calendar", "deleteEventById", [{
+    "id": id,
+    "fromTime": fromDate instanceof Date ? fromDate.getTime() : null
+  }]);
+};
+
 Calendar.prototype.modifyEventWithOptions = function (title, location, notes, startDate, endDate, newTitle, newLocation, newNotes, newStartDate, newEndDate, options, newOptions, successCallback, errorCallback) {
   if (!(newStartDate instanceof Date && newEndDate instanceof Date)) {
     errorCallback("newStartDate and newEndDate must be JavaScript Date Objects");

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -278,11 +278,16 @@ Calendar.prototype.listCalendars = function (successCallback, errorCallback) {
 };
 
 Calendar.prototype.parseEventDate = function (dateStr) {
-	var spl;
-	// Handle yyyy-MM-dd HH:mm:ss format returned by AbstractCalendarAccessor.java L66, Calendar.m L378, and most similar formats
-	return (spl = /^\s*(\d{4})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\s*$/.exec(dateStr))
-		&& new Date(spl[1], spl[2] - 1, spl[3], spl[4], spl[5], spl[6])
-		|| new Date(dateStr);
+  // Handle yyyyMMddTHHmmssZ iCalendar UTC format
+  var icalRegExp = /\b(\d{4})(\d{2})(\d{2}T\d{2})(\d{2})(\d{2}Z)\b/;
+  if (icalRegExp.test(dateStr))
+    return new Date(String(dateStr).replace(icalRegExp, '$1-$2-$3:$4:$5'));
+
+  var spl;
+  // Handle yyyy-MM-dd HH:mm:ss format returned by AbstractCalendarAccessor.java L66 and Calendar.m L378, and yyyyMMddTHHmmss iCalendar local format, and similar
+  return (spl = /^\s*(\d{4})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\s*$/.exec(dateStr))
+    && new Date(spl[1], spl[2] - 1, spl[3], spl[4], spl[5], spl[6])
+    || new Date(dateStr);
 };
 
 Calendar.install = function () {


### PR DESCRIPTION
_Note: builds upon #453 and #454. Please consider them first._

Adds `deleteEventById()` for iOS and Android. This provides a consistent way to differentiate between single events and recurring instances, while identifying them precisely and safely by the unique `id` returned by the create and find methods.

When `fromDate` is omitted (by passing `null`), this deletes all instances in a recurring set, or one ordinary non-repeating event.

When `fromDate` is specified, and event instances exist from that point onward, the recurrence end condition is changed so that they no longer exist.

Test coverage is included for most relevant cases, although Android calendar is quite fragile at times, as some types of updates to the Instances view get delayed until the next successful Sync.

This should address, or help with, issues #177, #178, #271, #382, #391.