### PR TITLE
fix deleteEvent() "notes" filter which was ignored on android

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Basic operations, you'll want to copy-paste this for testing purposes:
   newOptions.firstReminderMinutes = 120;
   window.plugins.calendar.modifyEventWithOptions(title,eventLocation,notes,startDate,endDate,newTitle,eventLocation,notes,startDate,endDate,filterOptions,newOptions,success,error);
 
-  // delete an event (you can pass nulls for irrelevant parameters, note that on Android `notes` is ignored). The dates are mandatory and represent a date range to delete events in.
+  // delete an event (you can pass nulls for irrelevant parameters). The dates are mandatory and represent a date range to delete events in.
   // note that on iOS there is a bug where the timespan must not be larger than 4 years, see issue 102 for details.. call this method multiple times if need be
   // since 4.3.0 you can match events starting with a prefix title, so if your event title is 'My app - cool event' then 'My app -' will match.
   window.plugins.calendar.deleteEvent(newTitle,eventLocation,notes,startDate,endDate,success,error);

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -453,7 +453,8 @@ public class Calendar extends CordovaPlugin {
                   jsonFilter.optLong("startTime"),
                   jsonFilter.optLong("endTime"),
                   getPossibleNullString("title", jsonFilter),
-                  getPossibleNullString("location", jsonFilter));
+                  getPossibleNullString("location", jsonFilter),
+                  getPossibleNullString("notes", jsonFilter));
 
           callback.sendPluginResult(new PluginResult(PluginResult.Status.OK, deleteResult));
         }

--- a/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/AbstractCalendarAccessor.java
@@ -495,9 +495,9 @@ public abstract class AbstractCalendarAccessor {
         return result;
     }
 
-    public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location) {
+    public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location, String notes) {
         ContentResolver resolver = this.cordova.getActivity().getApplicationContext().getContentResolver();
-        Event[] events = fetchEventInstances(null, title, location, "", startFrom, startTo);
+        Event[] events = fetchEventInstances(null, title, location, notes, startFrom, startTo);
         int nrDeletedRecords = 0;
         if (events != null) {
             for (Event event : events) {

--- a/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
@@ -83,9 +83,9 @@ public class CalendarProviderAccessor extends AbstractCalendarAccessor {
   }
 
   @Override
-  public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location) {
+  public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location, String notes) {
     eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
-    return super.deleteEvent(eventsUri, startFrom, startTo, title, location);
+    return super.deleteEvent(eventsUri, startFrom, startTo, title, location, notes);
   }
 
   @Override

--- a/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
@@ -85,9 +85,9 @@ public class LegacyCalendarAccessor extends AbstractCalendarAccessor {
   }
 
   @Override
-  public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location) {
+  public boolean deleteEvent(Uri eventsUri, long startFrom, long startTo, String title, String location, String notes) {
     eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER_PRE_FROYO + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
-    return super.deleteEvent(eventsUri, startFrom, startTo, title, location);
+    return super.deleteEvent(eventsUri, startFrom, startTo, title, location, notes);
   }
 
   @Override

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -381,7 +381,7 @@
     NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                   event.title, @"title",
                                   event.calendar.title, @"calendar",
-                                  event.eventIdentifier, @"id",
+                                  event.calendarItemIdentifier , @"id",
                                   [df stringFromDate:event.startDate], @"startDate",
                                   [df stringFromDate:event.endDate], @"endDate",
                                   [df stringFromDate:event.lastModifiedDate], @"lastModifiedDate",
@@ -460,7 +460,6 @@
       }
     }
 
-    [entry setObject:event.calendarItemIdentifier forKey:@"id"];
     [results addObject:entry];
   }
   return results;

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cordova-plugin-calendar-tests",
+  "version": "5.0.0",
+  "description": "",
+  "cordova": {
+    "id": "cordova-plugin-calendar-tests",
+    "platforms": []
+  },
+  "keywords": [
+    "ecosystem:cordova"
+  ],
+  "author": "",
+  "license": "Apache 2.0"
+}

--- a/test/plugin.xml
+++ b/test/plugin.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
+    xmlns:rim="http://www.blackberry.com/ns/widgets"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    id="cordova-plugin-calendar-tests"
+    version="5.0.0">
+    <name>Cordova Calendar Plugin Tests</name>
+    <license>Apache 2.0</license>
+
+    <js-module src="tests.js" name="tests">
+    </js-module>
+</plugin>

--- a/test/tests.js
+++ b/test/tests.js
@@ -86,6 +86,58 @@ exports.defineAutoTests = function() {
             });
         });
     });
+
+    itP('should support delete by title or date', function () {
+      var title = 'DF event' + runTag + ' ';
+      var first, bytitle, bydate, last;
+
+      // create
+      return createEventP(title + 'first', null, null, newDate(1, 7), newDate(1, 8))
+        .then(function (id) {
+          first = id;
+          return createEventP(title + 'bytitle', null, null, newDate(1, 9), newDate(1, 10));
+        })
+        .then(function (id) {
+          bytitle = id;
+          return createEventP(title + 'bydate', null, null, newDate(1, 11), newDate(1, 13));
+        })
+        .then(function (id) {
+          bydate = id;
+          return createEventP(title + 'last', null, null, newDate(1, 14), newDate(1, 15));
+        })
+        .then(function (id) {
+          last = id;
+
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.length).toBe(4);
+
+          // delete by title
+          return deleteEventP(title + 'bytitle', null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.map(function (e) { return e.id; })).toEqual([first, bydate, last]);
+
+          // delete by date
+          return deleteEventP(null, null, null, newDate(1, 11), newDate(1, 13));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expect(events.map(function (e) { return e.id; })).toEqual([first, last]);
+
+          // delete the rest
+          return deleteEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        });
+    });
   });
 
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -87,9 +87,9 @@ exports.defineAutoTests = function() {
         });
     });
 
-    itP('should support delete by title or date or location', function () {
+    itP('should support delete by title/date/location/notes', function () {
       var title = 'DF event' + runTag + ' ';
-      var first, bytitle, bydate, bylocation, last;
+      var first, bytitle, bydate, bylocation, bynotes, last;
 
       var expectedIds;
       var removeExpectedId = function (id) {
@@ -115,13 +115,17 @@ exports.defineAutoTests = function() {
         })
         .then(function (id) {
           bylocation = id;
-          return createEventP(title + 'last', null, null, newDate(1, 16), newDate(1, 17));
+          return createEventP(title, null, 'bynotes', newDate(1, 16), newDate(1, 17));
+        })
+        .then(function (id) {
+          bynotes = id;
+          return createEventP(title + 'last', null, null, newDate(1, 18), newDate(1, 19));
         })
         .then(function (id) {
           last = id;
 
           // find
-          expectedIds = [first, bytitle, bydate, bylocation, last];
+          expectedIds = [first, bytitle, bydate, bylocation, bynotes, last];
           return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function (events) {
@@ -152,6 +156,17 @@ exports.defineAutoTests = function() {
           // delete by location
           removeExpectedId(bylocation);
           return deleteEventP(null, 'bylocation', null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expectIds(events);
+
+          // delete by notes
+          removeExpectedId(bynotes);
+          return deleteEventP(null, null, 'bynotes', newDate(1, 0), newDate(2, 0));
         })
         .then(function () {
           // find

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,14 +1,5 @@
 exports.defineAutoTests = function() {
   
-  var fail = function (done) {
-    expect(true).toBe(false);
-    done();
-  },
-  succeed = function (done) {
-    expect(true).toBe(true);
-    done();
-  };
-
   describe('Plugin availability', function () {
     it("window.plugins.calendar should exist", function() {
       expect(window.plugins.calendar).toBeDefined();
@@ -20,17 +11,4 @@ exports.defineAutoTests = function() {
       expect(window.plugins.calendar.createEventWithOptions).toBeDefined();
     });
   });
-
-  /*
-  TODO extend - this is a copy-paste example of Toast
-  describe('Invalid usage', function () {
-    it("should fail due to an invalid position", function(done) {
-     window.plugins.toast.show('hi', 'short', 'nowhere', fail.bind(null, done), succeed.bind(null, done));
-    });
-
-    it("should fail due to an invalid duration", function(done) {
-     window.plugins.toast.show('hi', 'medium', 'top', fail.bind(null, done), succeed.bind(null, done));
-    });
-  });
-  */
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -87,9 +87,9 @@ exports.defineAutoTests = function() {
         });
     });
 
-    itP('should support delete by title or date', function () {
+    itP('should support delete by title or date or location', function () {
       var title = 'DF event' + runTag + ' ';
-      var first, bytitle, bydate, last;
+      var first, bytitle, bydate, bylocation, last;
 
       var expectedIds;
       var removeExpectedId = function (id) {
@@ -111,13 +111,17 @@ exports.defineAutoTests = function() {
         })
         .then(function (id) {
           bydate = id;
-          return createEventP(title + 'last', null, null, newDate(1, 14), newDate(1, 15));
+          return createEventP(title, 'bylocation', null, newDate(1, 14), newDate(1, 15));
+        })
+        .then(function (id) {
+          bylocation = id;
+          return createEventP(title + 'last', null, null, newDate(1, 16), newDate(1, 17));
         })
         .then(function (id) {
           last = id;
 
           // find
-          expectedIds = [first, bytitle, bydate, last];
+          expectedIds = [first, bytitle, bydate, bylocation, last];
           return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function (events) {
@@ -137,6 +141,17 @@ exports.defineAutoTests = function() {
           // delete by date
           removeExpectedId(bydate);
           return deleteEventP(null, null, null, newDate(1, 11), newDate(1, 13));
+        })
+        .then(function () {
+          // find
+          return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
+        })
+        .then(function (events) {
+          expectIds(events);
+
+          // delete by location
+          removeExpectedId(bylocation);
+          return deleteEventP(null, 'bylocation', null, newDate(1, 0), newDate(2, 0));
         })
         .then(function () {
           // find

--- a/test/tests.js
+++ b/test/tests.js
@@ -91,6 +91,14 @@ exports.defineAutoTests = function() {
       var title = 'DF event' + runTag + ' ';
       var first, bytitle, bydate, last;
 
+      var expectedIds;
+      var removeExpectedId = function (id) {
+        expectedIds = expectedIds.filter(function (x) { return x != id; });
+      };
+      var expectIds = function (events) {
+        expect(events.map(function (e) { return e.id; })).toEqual(expectedIds);
+      };
+
       // create
       return createEventP(title + 'first', null, null, newDate(1, 7), newDate(1, 8))
         .then(function (id) {
@@ -109,12 +117,14 @@ exports.defineAutoTests = function() {
           last = id;
 
           // find
+          expectedIds = [first, bytitle, bydate, last];
           return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function (events) {
-          expect(events.length).toBe(4);
+          expectIds(events);
 
           // delete by title
+          removeExpectedId(bytitle);
           return deleteEventP(title + 'bytitle', null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function () {
@@ -122,9 +132,10 @@ exports.defineAutoTests = function() {
           return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function (events) {
-          expect(events.map(function (e) { return e.id; })).toEqual([first, bydate, last]);
+          expectIds(events);
 
           // delete by date
+          removeExpectedId(bydate);
           return deleteEventP(null, null, null, newDate(1, 11), newDate(1, 13));
         })
         .then(function () {
@@ -132,7 +143,7 @@ exports.defineAutoTests = function() {
           return findEventP(title, null, null, newDate(1, 0), newDate(2, 0));
         })
         .then(function (events) {
-          expect(events.map(function (e) { return e.id; })).toEqual([first, last]);
+          expectIds(events);
 
           // delete the rest
           return deleteEventP(title, null, null, newDate(1, 0), newDate(2, 0));

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,5 +1,51 @@
 exports.defineAutoTests = function() {
   
+  var itP = function (description, fn, timeout) {
+    it(description, function (done) {
+      Promise.resolve(fn())
+        .catch(fail)
+        .then(done, done);
+    }, timeout);
+  };
+
+  var runTime = new Date();
+  var runId = Math.floor((runTime - new Date(runTime).setHours(0, 0, 0, 0)) / 1000);
+  var runTag = ' [cpctZQX' + runId + ']';
+
+  var promisifyScbEcb = function (func) {
+    if (typeof(func) != 'function')
+      throw 'not a function: ' + func;
+    return function () {
+      var args = arguments;
+      return new Promise(function (resolve, reject) {
+        func.apply(null, Array.prototype.slice.call(args).concat(resolve, reject));
+      });
+    };
+  };
+  var deleteEventP = promisifyScbEcb(plugins.calendar.deleteEvent);
+  var findEventP = promisifyScbEcb(plugins.calendar.findEvent);
+  var createEventP = promisifyScbEcb(plugins.calendar.createEvent);
+  var parseEventDate = plugins.calendar.parseEventDate;
+
+  var newDate = function (dd, hh, mm) {
+    return new Date(2018, 0, 21 + dd, hh || 0, mm || 0);
+  };
+
+
+  beforeEach(function (done) {
+    /* clean up autotest data */
+    return deleteEventP('[cpctZQX', null, null, newDate(1), newDate(8))
+      .then(function () {
+        return findEventP(runTag, null, null, newDate(1), newDate(8));
+      })
+      .then(function (events) {
+        expect(events.length).toBe(0, 'if test data was cleaned up');
+      })
+      .catch(fail)
+      .then(done, done);
+  });
+
+
   describe('Plugin availability', function () {
     it("window.plugins.calendar should exist", function() {
       expect(window.plugins.calendar).toBeDefined();
@@ -11,4 +57,35 @@ exports.defineAutoTests = function() {
       expect(window.plugins.calendar.createEventWithOptions).toBeDefined();
     });
   });
+
+  describe('createEvent / findEvent / deleteEvent', function () {
+    itP('should create, find, then delete an event', function () {
+      var title = 'CFD event' + runTag;
+
+      // create
+      return createEventP(title, null, null, newDate(2, 18), newDate(2, 19))
+        .then(function (id) {
+          // find
+          return findEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+            .then(function (events) {
+              expect(events.length).toBe(1);
+              expect(events[0].title).toBe(title);
+              expect(parseEventDate(events[0].startDate)).toEqual(newDate(2, 18));
+              expect(parseEventDate(events[0].endDate)).toEqual(newDate(2, 19));
+              expect(events[0].id).toBe(id);
+            });
+        })
+        .then(function () {
+          // delete
+          return deleteEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+            .then(function () {
+              return findEventP(title, null, null, newDate(2, 17), newDate(2, 20))
+                .then(function (events) {
+                  expect(events.length).toBe(0);
+                });
+            });
+        });
+    });
+  });
+
 };

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -270,6 +270,14 @@ Calendar.prototype.listCalendars = function (successCallback, errorCallback) {
   cordova.exec(successCallback, errorCallback, "Calendar", "listCalendars", []);
 };
 
+Calendar.prototype.parseEventDate = function (dateStr) {
+	var spl;
+	// Handle yyyy-MM-dd HH:mm:ss format returned by AbstractCalendarAccessor.java L66, Calendar.m L378, and most similar formats
+	return (spl = /^\s*(\d{4})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\D?(\d{2})\s*$/.exec(dateStr))
+		&& new Date(spl[1], spl[2] - 1, spl[3], spl[4], spl[5], spl[6])
+		|| new Date(dateStr);
+};
+
 Calendar.install = function () {
   if (!window.plugins) {
     window.plugins = {};


### PR DESCRIPTION
_Note: builds upon #453 and #454. Please consider them first._

This brings ```deleteEvent()``` filtering in line with ```findEvent()```, by no longer ignoring the ```notes``` parameter. It adds some safety against unintended deletes, resolves the ios/android platform difference, and addresses #366 and possibly some of the concerns in #411.

Includes test coverage.