### PR TITLE
fix ios removeEvent

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -153,7 +153,7 @@
 
       // Find matches
       if (calEventID != nil) {
-          theEvent = (EKEvent *)[self.eventStore calendarItemWithIdentifier:calEventID];
+          theEvent = (EKEvent *)[self.eventStore eventWithIdentifier:calEventID];
       }
 
     if (theEvent == nil) {
@@ -246,7 +246,7 @@
       if (error) {
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.userInfo.description];
       } else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:theEvent.calendarItemIdentifier];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:theEvent.eventIdentifier];
       }
     } else {
       // Otherwise return a no result error (could be more than 1, but not a biggie)
@@ -381,7 +381,7 @@
     NSMutableDictionary *entry = [[NSMutableDictionary alloc] initWithObjectsAndKeys:
                                   event.title, @"title",
                                   event.calendar.title, @"calendar",
-                                  event.calendarItemIdentifier , @"id",
+                                  event.eventIdentifier , @"id",
                                   [df stringFromDate:event.startDate], @"startDate",
                                   [df stringFromDate:event.endDate], @"endDate",
                                   [df stringFromDate:event.lastModifiedDate], @"lastModifiedDate",
@@ -631,7 +631,7 @@
     if (error) {
       pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.userInfo.description];
     } else {
-      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:myEvent.calendarItemIdentifier];
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:myEvent.eventIdentifier];
     }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
   }];
@@ -781,7 +781,7 @@
   [self.commandDelegate runInBackground: ^{
 
     // Get original instance
-    EKEvent* firstEvent = (EKEvent *)[eventStore calendarItemWithIdentifier:ciid];
+    EKEvent* firstEvent = (EKEvent *)[eventStore eventWithIdentifier:ciid];
     if (firstEvent == nil) {
       // Fail
       [self.commandDelegate
@@ -899,7 +899,7 @@
     // Find matches
     EKCalendarItem *theEvent = nil;
     if (calEventID != nil) {
-      theEvent = [self.eventStore calendarItemWithIdentifier:calEventID];
+      theEvent = [self.eventStore eventWithIdentifier:calEventID];
     }
 
     NSArray *matchingEvents;
@@ -1000,7 +1000,7 @@
 
     case EKEventEditViewActionSaved:
       [controller.eventStore saveEvent:controller.event span:EKSpanThisEvent error:&error];
-      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:controller.event.calendarItemIdentifier];
+      pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:controller.event.eventIdentifier];
       break;
 
     case EKEventEditViewActionDeleted:


### PR DESCRIPTION
The `removeEvent` wants an event and probably `calendarItemWithIdentifier` didn't return it.
From official documentation: 

> calendarItemWithIdentifier: can fetch any calendar item (reminders and events), whereas eventWithIdentifier: fetches only events

Indeed `eventWithIdentifier` release nil, so the id passed is wrong to fetch event.

Then I replaced the event property read from `calendarItemIdentifier` to `eventIdentifier` and the used method from `calendarItemWithIdentifier` to `eventWithIdentifier`.