### PR TITLE
Add contacts usage description

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -55,6 +55,12 @@
     <config-file target="*-Info.plist" parent="NSCalendarsUsageDescription">
       <string>$CALENDAR_USAGE_DESCRIPTION</string>
     </config-file>
+    <!-- Usage description for Contacts needed in some iOS versions when searching 
+      for locations and invitees using the interactive mode  -->
+    <preference name="CONTACTS_USAGE_DESCRIPTION" default=" " />
+    <config-file target="*-Info.plist" parent="NSContactsUsageDescription">
+      <string>$CONTACTS_USAGE_DESCRIPTION</string>
+    </config-file>
     <header-file src="src/ios/Calendar.h"/>
     <source-file src="src/ios/Calendar.m"/>
     <framework src="EventKit.framework"/>


### PR DESCRIPTION
Adding a location or invitee to a calendar event would crash the app in some devices (confirmed on iPhone 6, iOS 11.4.1).
When adding a location or invitee a search is made for possible locations and invitees in the user's contacts and since the contacts usage description is missing the app will crash.