### PR TITLE
Implementation of the feature to add attendees (email) interactively and silently at the event creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,9 @@ Basic operations, you'll want to copy-paste this for testing purposes:
   // And the URL can be passed since 4.3.2 (will be appended to the notes on Android as there doesn't seem to be a sep field)
   calOptions.url = "https://www.google.com";
 
+  // Accepts an array containing the participants e-mails, like this:
+  calOptions.attendees = ["example@example.com", "example1@example1.com", "example2@example2.com"];
+
   // on iOS the success handler receives the event ID (since 4.3.6)
   window.plugins.calendar.createEventWithOptions(title,eventLocation,notes,startDate,endDate,calOptions,success,error);
 

--- a/src/android/nl/xservices/plugins/Calendar.java
+++ b/src/android/nl/xservices/plugins/Calendar.java
@@ -405,6 +405,12 @@ public class Calendar extends CordovaPlugin {
           calIntent.putExtra("description", description);
           calIntent.putExtra("calendar_id", argOptionsObject.optInt("calendarId", 1));
 
+          String[] attendees = getPossibleNullArray("attendees", argOptionsObject);
+
+          if (attendees != null) {
+            calIntent
+              .putExtra("android.intent.extra.EMAIL", attendees);
+          }
           //set recurrence
           String recurrence = getPossibleNullString("recurrence", argOptionsObject);
           Long recurrenceEndTime = argOptionsObject.isNull("recurrenceEndTime") ? null : argOptionsObject.optLong("recurrenceEndTime");
@@ -577,7 +583,8 @@ public class Calendar extends CordovaPlugin {
                     argOptionsObject.optLong("recurrenceCount", -1),
                     getPossibleNullString("allday", argOptionsObject),
                     argOptionsObject.optInt("calendarId", 1),
-                    getPossibleNullString("url", argOptionsObject));
+                    getPossibleNullString("url", argOptionsObject),
+                    getPossibleNullArray("attendees", argOptionsObject));
             if (createdEventID != null) {
               callback.success(createdEventID);
             } else {
@@ -596,6 +603,23 @@ public class Calendar extends CordovaPlugin {
 
   private static String getPossibleNullString(String param, JSONObject from) {
     return from.isNull(param) || "null".equals(from.optString(param)) ? null : from.optString(param);
+  }
+
+  private static String[] getPossibleNullArray(String param, JSONObject from) {
+    String[] arr = null;
+
+    try {
+      JSONArray arrJson = from.getJSONArray(param);
+      arr = new String[arrJson.length()];
+
+      for(int i = 0; i < arrJson.length(); i++) {
+        arr[i] = arrJson.getString(i);
+      }
+    } catch (JSONException e) {
+      System.err.println("Exception: " + e.getMessage());
+    }
+
+    return arr;
   }
 
   private void listEventsInRange(JSONArray args) {

--- a/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/CalendarProviderAccessor.java
@@ -99,10 +99,10 @@ public class CalendarProviderAccessor extends AbstractCalendarAccessor {
                             String description, String location, Long firstReminderMinutes, Long secondReminderMinutes,
                             String recurrence, int recurrenceInterval, String recurrenceWeekstart,
                             String recurrenceByDay, String recurrenceByMonthDay, Long recurrenceEndTime, Long recurrenceCount,
-                            String allday, Integer calendarId, String url) {
+                            String allday, Integer calendarId, String url, String[] attendees) {
     eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
     return super.createEvent(eventsUri, title, startTime, endTime, description, location,
             firstReminderMinutes, secondReminderMinutes, recurrence, recurrenceInterval, recurrenceWeekstart,
-            recurrenceByDay, recurrenceByMonthDay, recurrenceEndTime, recurrenceCount, allday, calendarId, url);
+            recurrenceByDay, recurrenceByMonthDay, recurrenceEndTime, recurrenceCount, allday, calendarId, url, attendees);
   }
 }

--- a/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
+++ b/src/android/nl/xservices/plugins/accessor/LegacyCalendarAccessor.java
@@ -102,11 +102,11 @@ public class LegacyCalendarAccessor extends AbstractCalendarAccessor {
                             String description, String location, Long firstReminderMinutes, Long secondReminderMinutes,
                             String recurrence, int recurrenceInterval, String recurrenceWeekstart,
                             String recurrenceByDay, String recurrenceByMonthDay, Long recurrenceEndTime, Long recurrenceCount,
-                            String allday, Integer calendarId, String url) {
+                            String allday, Integer calendarId, String url, String[] attendees) {
     eventsUri = eventsUri == null ? Uri.parse(CONTENT_PROVIDER_PRE_FROYO + CONTENT_PROVIDER_PATH_EVENTS) : eventsUri;
     return super.createEvent(eventsUri, title, startTime, endTime, description, location,
             firstReminderMinutes, secondReminderMinutes, recurrence, recurrenceInterval, recurrenceWeekstart,
-            recurrenceByDay, recurrenceByMonthDay, recurrenceEndTime, recurrenceCount, allday, calendarId, url);
+            recurrenceByDay, recurrenceByMonthDay, recurrenceEndTime, recurrenceCount, allday, calendarId, url, attendees);
   }
 
 }

--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -530,7 +530,7 @@
       pluginResult = [CDVPluginResult resultWithStatus: CDVCommandStatus_OK messageAsArray:eventsDataArray];
 
       [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-  }];  
+  }];
 }
 
 - (void)createEventWithOptions:(CDVInvokedUrlCommand*)command {
@@ -550,6 +550,7 @@
   NSNumber* recurrenceIntervalAmount = [calOptions objectForKey:@"recurrenceInterval"];
   NSString* calendarName = [calOptions objectForKey:@"calendarName"];
   NSString* url = [calOptions objectForKey:@"url"];
+  NSArray* attendees = [calOptions objectForKey:@"attendees"];
 
   [self.commandDelegate runInBackground: ^{
     EKEvent *myEvent = [EKEvent eventWithEventStore: self.eventStore];
@@ -620,6 +621,18 @@
       [myEvent addAlarm:reminder];
     }
 
+    NSMutableArray *attendeesObjectsList = [NSMutableArray new];
+    if (attendees != (id)[NSNull null]) {
+      NSUInteger size = [attendees count];
+      for (int i = 0; i < size; i++) {
+        Class className = NSClassFromString(@"EKAttendee");
+        id attendee = [className new];
+        [attendee setValue:[NSString stringWithFormat:@"%@", [attendees objectAtIndex: i]] forKey:@"emailAddress"];
+        [attendeesObjectsList addObject:attendee];
+      }
+      [myEvent setValue:attendeesObjectsList forKey:@"attendees"];
+    }
+
     if (recurrence != (id)[NSNull null]) {
       EKRecurrenceRule *rule = [[EKRecurrenceRule alloc] initRecurrenceWithFrequency: [self toEKRecurrenceFrequency:recurrence]
                                                                             interval: recurrenceIntervalAmount.integerValue
@@ -662,6 +675,7 @@
   NSString* calendarName = [calOptions objectForKey:@"calendarName"];
   NSString* url = [calOptions objectForKey:@"url"];
   NSNumber* intervalAmount = [calOptions objectForKey:@"recurrenceInterval"];
+  NSArray* attendees = [calOptions objectForKey:@"attendees"];
 
   EKEvent *myEvent = [EKEvent eventWithEventStore: self.eventStore];
   if (url != (id)[NSNull null]) {
@@ -728,6 +742,18 @@
     if (secondReminderMinutes != (id)[NSNull null]) {
       EKAlarm *reminder = [EKAlarm alarmWithRelativeOffset:-1 * secondReminderMinutes.intValue * 60];
       [myEvent addAlarm:reminder];
+    }
+
+    NSMutableArray *attendeesObjectsList = [NSMutableArray new];
+    if (attendees != (id)[NSNull null]) {
+      NSUInteger size = [attendees count];
+      for (int i = 0; i < size; i++) {
+        Class className = NSClassFromString(@"EKAttendee");
+        id attendee = [className new];
+        [attendee setValue:[NSString stringWithFormat:@"%@", [attendees objectAtIndex: i]] forKey:@"emailAddress"];
+        [attendeesObjectsList addObject:attendee];
+      }
+      [myEvent setValue:attendeesObjectsList forKey:@"attendees"];
     }
 
     if (recurrence != (id)[NSNull null]) {

--- a/www/Calendar.js
+++ b/www/Calendar.js
@@ -81,7 +81,8 @@ Calendar.prototype.getCalendarOptions = function () {
     recurrenceCount: null,
     calendarName: null,
     calendarId: null,
-    url: null
+    url: null,
+    attendees: null
   };
 };
 


### PR DESCRIPTION
Hi, here is the feature I said I was going to work with.

With this pull request users will be able to add attendees to events passing the "attendees" option key in the options object. The value of this key must be an array of strings, those strings must be the participants e-mails. Interactively, silently, with and without options, everything worked just fine.

I tested on my iPhone 8 with iOS version 13.3.1 and on a Samsung Galaxy A10 with Android version 9.

Please review my changes and let me know if there is anything else I can do to make this feature come to main line.

Thanks!
