### PR TITLE
Update Calendar.m

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -747,11 +747,14 @@
 
     self.interactiveCallbackId = command.callbackId;
 
-    EKEventEditViewController* controller = [[EKEventEditViewController alloc] init];
-    controller.event = myEvent;
-    controller.eventStore = self.eventStore;
-    controller.editViewDelegate = self;
     dispatch_async(dispatch_get_main_queue(), ^{
+    
+        //Fix ios 15.1 -- Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread
+        EKEventEditViewController* controller = [[EKEventEditViewController alloc] init];
+        controller.event = myEvent;
+        controller.eventStore = self.eventStore;
+        controller.editViewDelegate = self;
+        //Fix ios 15.1
         [self.viewController presentViewController:controller animated:YES completion:nil];
     });
   }];


### PR DESCRIPTION
Fix ios 15.1 -- Modifications to the layout engine must not be performed from a background thread after it has been accessed from the main thread.