### PR TITLE
Add support for iOS 17 and fix the non-access problem for calendars

### DIFF
--- a/src/ios/Calendar.m
+++ b/src/ios/Calendar.m
@@ -16,22 +16,16 @@
 }
 
 - (void) initEventStoreWithCalendarCapabilities {
-  __block BOOL accessGranted = NO;
-  EKEventStore* eventStoreCandidate = [[EKEventStore alloc] init];
-  if([eventStoreCandidate respondsToSelector:@selector(requestAccessToEntityType:completion:)]) {
-    dispatch_semaphore_t sema = dispatch_semaphore_create(0);
-    [eventStoreCandidate requestAccessToEntityType:EKEntityTypeEvent completion:^(BOOL granted, NSError *error) {
-      accessGranted = granted;
-      dispatch_semaphore_signal(sema);
-    }];
-    dispatch_semaphore_wait(sema, DISPATCH_TIME_FOREVER);
-  } else { // we're on iOS 5 or older
-    accessGranted = YES;
-  }
+	EKEventStore* eventStoreCandidate = [[EKEventStore alloc] init];
 
-  if (accessGranted) {
-    self.eventStore = eventStoreCandidate;
-  }
+	[eventStoreCandidate requestFullAccessToEventsWithCompletion:^(BOOL granted, NSError *error) {
+		if (granted) {
+			self.eventStore = eventStoreCandidate;
+			NSLog(@"Full access to the event store granted and eventStore initialized.");
+		} else {
+			NSLog(@"Access to the event store not granted. Error: %@", error.localizedDescription);
+		}
+	}];
 }
 
 #pragma mark Helper Functions


### PR DESCRIPTION
Added support for iOS 17 and a fix for the issue described here: https://github.com/EddyVerbruggen/Calendar-PhoneGap-Plugin/issues/565

For the fix to work you need to make sure you ask for permissions in `deviceready` and the app must be built with iOS17 as a target in XCode. 

Do this for `deviceready`:
```javascript
document.addEventListener('deviceready', () => {
	try {
		await calendarAccess();
	} catch (error) {
		console.log({error});
	}
});

``` 

A suggested function to run async is this:
```javascript
async function calendarAccess() {
return new Promise((resolve, reject) => {
	// Check if we have permission to access the calendar
	window.plugins.calendar.hasReadWritePermission(
		(result) => {
			if (result === true) {
				// We already have permission
				console.log("We have calendar permissions.");
				resolve(true); // Resolve the promise with true, indicating permission is already granted
			} else {
				// We do not have permission, so let's request it
				window.plugins.calendar.requestReadWritePermission(
					() => {
						// Permission request was successful
						console.log("Calendar permissions granted.");
						resolve(true); // Resolve the promise with true, indicating permission is granted now
					},
					(err) => {
						// Permission request failed
						console.error("Calendar permissions were not granted:", err);
						reject(err); // Reject the promise with the error
					}
				);
			}
		},
		(err) => {
			// Error occurred while checking permissions
			console.error("Error checking calendar permissions:", err);
			reject(err); // Reject the promise with the error
		}
	);
});
```